### PR TITLE
Removed @Override from createJSModules method.

### DIFF
--- a/android/src/main/java/br/com/dopaminamob/gpsstate/GPSStatePackage.java
+++ b/android/src/main/java/br/com/dopaminamob/gpsstate/GPSStatePackage.java
@@ -27,7 +27,6 @@ public class GPSStatePackage implements ReactPackage {
 		return modules;
 	}
 	
-	@Override
 	public List<Class<? extends JavaScriptModule>> createJSModules() {
 		return Collections.emptyList();
 	}


### PR DESCRIPTION
The current version of React Native (> 0.47) has removed the createJSModules method in ReactPackage. Therefore any overrides of this method will need to be removed from the library, or this will cause a compilation error.