### PR TITLE
prevent Android Studio merger issues

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,14 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
-          package="br.com.dopaminamob.gpsstate"
->
+          package="br.com.dopaminamob.gpsstate">
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<application android:allowBackup="true"
-	             android:label="@string/app_name"
-	             android:supportsRtl="true"
-	>
-	
-	</application>
 
+	<application android:label="@string/app_name"></application>
 </manifest>


### PR DESCRIPTION
Fix the issue encountered using gradle in app with (at least) the 28th revisions environment.
Output :
```
.../some/path/AndroidManifest.xml:38:9-36 Error:
        Attribute application@allowBackup value=(false) from AndroidManifest.xml:38:9-36
        is also present at [:react-native-gps-state] AndroidManifest.xml:15:9-35 value=(true).
        Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:36:5-257:19 to override.
```

Since the library does not need an AndroidManifest.xml with those decorations, it is safer and better to remove them altogether

_Note : I'm proposing a PR directly in the master branch, don't know if needs to be submitted into dev_